### PR TITLE
Add “infinite” mode

### DIFF
--- a/jquery.countdown.js
+++ b/jquery.countdown.js
@@ -286,7 +286,7 @@ $.extend(Countdown.prototype, {
 				if (inst.options.expiryUrl) {
 					window.location = inst.options.expiryUrl;
 				}
-				if (inst.options.infinite && inst.options.until.match(/^\+\d+$/)) {
+				if (inst.options.infinite && typeof inst.options.until == 'string' && inst.options.until.match(/^\+\d/)) {
 					this._optionPlugin(target, 'until', inst.options.until);
 				}
 			}


### PR DESCRIPTION
I (and [many](http://stackoverflow.com/questions/15803937/restart-countdown-timer-when-expired other) [others](http://stackoverflow.com/questions/15803937/restart-countdown-timer-when-expired)) would like timers that automatically reset themselves after expiry. An example use case would just be someone (like me) who wants to update a status page every 30 seconds. Sure, I _could_ just use setInterval, but I like to show a little countdown that displays how long until the page auto-refreshes itself. I could also just restart the timer myself (outside the plugin), but I’d prefer for this functionality to be built in.

I added an `infinite` option that does just that. If you set `infinite` to `true` **_and**_ you have an `until` option that is a relative time, then the timer restarts after it expires. If you have an `until` that is a date, infinite mode doesn’t really make sense, so nothing happens in that case.

**Disclaimer** - this code works awesome for me, but I have not tested it against all the possible configurations and uses.
