### PR TITLE
fixed bower.json by removing BOM

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "kbwood_countdown",
   "version": "2.0.2",
   "description": "This plugin sets a div or span to show a countdown to a given time. * Standard or compact formats, or create your own layout. * Decide which periods to show. * Count up from a date/time instead. * Cater for timezone differences and synchronise with server time. * Over 50 localisations.",


### PR DESCRIPTION
Apparently this needs a new tag to get this working correctly

>$ bower install https://github.com/d1g1t/countdown.git#2.0.2.1
>bower cached        https://github.com/d1g1t/countdown.git#2.0.2.1
>bower validate      2.0.2.1 against https://github.com/d1g1t/countdown.git#2.0.2.1
>bower install       kbwood_countdown#2.0.2.1
>
>kbwood_countdown#2.0.2.1 jsunmin/deps/kbwood_countdown
>└── jquery#2.1.3
