### PR TITLE
Update jquery.countdown.js

### DIFF
--- a/jquery.countdown.js
+++ b/jquery.countdown.js
@@ -354,9 +354,11 @@
 			if ($.isFunction(inst.options.onTick)) {
 				var periods = inst._hold != 'lap' ? inst._periods :
 					this._calculatePeriods(inst, inst._show, inst.options.significant, new Date());
-				if (inst.options.tickInterval == 1 ||
-						this.periodsToSeconds(periods) % inst.options.tickInterval == 0) {
-					inst.options.onTick.apply(elem[0], [periods]);
+				if ( inst._hold != 'pause' ){
+					if (inst.options.tickInterval == 1 ||
+							this.periodsToSeconds(periods) % inst.options.tickInterval == 0) {
+						inst.options.onTick.apply(elem[0], [periods]);
+					}
 				}
 			}
 			var expired = inst._hold != 'pause' &&


### PR DESCRIPTION
If you call countdown('pause') from within the onTick callback, it will put you in an infinite loop. This extra if statement will make the code jump over the "onTick" logic for pause commands